### PR TITLE
Declare cssfmt as command

### DIFF
--- a/cssfmt.el
+++ b/cssfmt.el
@@ -23,8 +23,10 @@
   "The 'cssfmt' command."
   :type 'string)
 
+;;;###autoload
 (defun cssfmt ()
   "Format the current buffer according to the cssfmt tool."
+  (interactive)
   (save-excursion
     (call-process cssfmt-command nil nil nil (buffer-file-name (current-buffer)))
     (revert-buffer t t t)))


### PR DESCRIPTION
And autoload cookie for lazy loading.

README.md says `M-x cssfmt` but `cssfmt` is not a command now, it is only a function.
