### PR TITLE
Define group for customize

### DIFF
--- a/cssfmt.el
+++ b/cssfmt.el
@@ -19,9 +19,14 @@
 ;;   (add-hook 'css-mode-hook 'cssfmt-enable-on-save)
 ;;; Code:
 
+(defgroup cssfmt nil
+  "'cssfmt' interface."
+  :group 'css)
+
 (defcustom cssfmt-command "cssfmt"
   "The 'cssfmt' command."
-  :type 'string)
+  :type 'string
+  :group 'cssfmt)
 
 (defun cssfmt ()
   "Format the current buffer according to the cssfmt tool."


### PR DESCRIPTION
Not specifying `:group` parameter causes byte-compile warning below.

```
cssfmt.el:22:1:Warning: defcustom for `cssfmt-command' fails to specify
    containing group
cssfmt.el:22:1:Warning: defcustom for `cssfmt-command' fails to specify
    containing group
```

Here is a gif animation of this changed version.

![output](https://cloud.githubusercontent.com/assets/554281/9325797/0b5ce6c8-45d0-11e5-8dfd-1de714ed3396.gif)
